### PR TITLE
VM-54: Fix SKY66112 FEM overdrive on USB840X dongles

### DIFF
--- a/src/src/platform-fem.h
+++ b/src/src/platform-fem.h
@@ -65,8 +65,8 @@ void nrf5FemDisable(void);
 /**
  * Retrieve the state of the CHL pin on the SKY66112.
  *
- * @retval	true	CHL is high (SKY66112 is in high-gain mode)
- * @retval	false	CHL is low (SKY66112 is in low-gain mode)
+ * @retval  true    CHL is high (SKY66112 is in high-gain mode)
+ * @retval  false   CHL is low (SKY66112 is in low-gain mode)
  */
 bool nrf5RadioGetChl(void);
 
@@ -74,19 +74,28 @@ bool nrf5RadioGetChl(void);
  * Set the state of the CHL pin on the SKY66112.  Putting the pin in
  * a high state (`aState=true`) enables high-gain mode.
  *
- * @param	aState	State of the CHL pin.
+ * @param   aState  State of the CHL pin.
  */
 void nrf5RadioSetChl(bool aState);
 
 /**
  * Define the gain of the front-end module used in dB.
+ *
+ * SKY66112 saturated gain in high-power mode (CHL=1) is ~22 dB.
+ * At the recommended operating point (PIN=-1 dBm), effective gain
+ * is ~20 dB (see datasheet Table 5, Figure 3).
  */
-#define OPENTHREAD_CONFIG_NRF5_FEM_TXGAIN	(16)
+#define OPENTHREAD_CONFIG_NRF5_FEM_TXGAIN (20)
 
 /**
  * Define the maximum FEM input power in dBm.
+ *
+ * SKY66112 absolute maximum input is +5 dBm (datasheet Table 2),
+ * but the recommended operating point is PIN=-1 dBm for +21 dBm
+ * output (datasheet Table 5).  Exceeding 0 dBm input drives the
+ * PA into deep compression with excessive current draw and heat.
  */
-#define OPENTHREAD_CONFIG_NRF5_FEM_MAX_INPUT	(5)
+#define OPENTHREAD_CONFIG_NRF5_FEM_MAX_INPUT (0)
 
 #endif // OPENTHREAD_CONFIG_NRF5_WITH_SKY66112
 


### PR DESCRIPTION
- Reduced SKY66112 FEM PA input power from +5 dBm (absolute max rating) to 0 dBm
- Corrected TXGAIN from 25 dB to 20 dB to match actual PA gain at recommended operating point
- Total output power remains at +20 dBm within safe limits

Root Cause: FEM PA driven at absolute max input, causing excessive current draw that increases with temperature. In warm enclosures (>65°C), peak current spikes caused USB voltage droop → USB disconnect → unrecoverable dongle fai